### PR TITLE
Add result object to error in parseResponse

### DIFF
--- a/src/providers/HttpProviderUtils.js
+++ b/src/providers/HttpProviderUtils.js
@@ -43,7 +43,12 @@ class HttpProviderUtils {
     }
 
     static parseResponse(result) {
-        if (result.exit_code !== 0) throw new Error(result);
+        if (result.exit_code !== 0) {
+            const err = new Error('parse response error')
+            err.result = result
+            throw err
+        }
+
         const arr = result.stack.map(HttpProviderUtils.parseResponseStack);
         return arr.length === 1 ? arr[0] : arr;
     }


### PR DESCRIPTION
When call to contract like `await nftCollection.methods.getNftItemContent(nftItem)` results in error, parseResponse throws error from result object which results in error with text `[object Object]`. If we add result as field to the error we then can handle different result cases in code that calls contract.