### PR TITLE
Multibyte string support

### DIFF
--- a/src/boc/BitString.js
+++ b/src/boc/BitString.js
@@ -178,12 +178,16 @@ class BitString {
     }
 
     /**
-     * @param s {string}
+     * Represents the specified multibyte string as bytes and writes
+     * them to the bit-string, starting at the current index and
+     * advances the current index cursor by the number of bits written.
+     *
+     * @param value {string}
      */
-    writeString(s) {
-        for (let i = 0; i < s.length; i++) {
-            this.writeUint8(s.charCodeAt(i));
-        }
+    writeString(value) {
+        this.writeBytes(
+            new TextEncoder().encode(value)
+        );
     }
 
     /**

--- a/src/contract/wallet/WalletContract.js
+++ b/src/contract/wallet/WalletContract.js
@@ -184,11 +184,8 @@ class WalletContract extends Contract {
             if (payload.refs) { // is Cell
                 payloadCell = payload;
             } else if (typeof payload === 'string') {
-                if (payload.length > 0) {
-                    payloadCell.bits.writeUint(0, 32);
-                    const payloadBytes = new TextEncoder().encode(payload);
-                    payloadCell.bits.writeBytes(payloadBytes);
-                }
+                payloadCell.bits.writeUint(0, 32);
+                payloadCell.bits.writeString(payload);
             } else {
                 payloadCell.bits.writeBytes(payload)
             }


### PR DESCRIPTION
- updated `BitString.writeString()` method to support multibyte-strings
- updated `WalletContract` to use `BitString.writeString()` method

Signed-off-by: Slava Fomin II <slava@fomin.io>