### PR TITLE
Improved and fixed apiKey input to HttpProvider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ class TonWeb {
         this.BlockSubscription = BlockSubscription;
         this.InMemoryBlockStorage = InMemoryBlockStorage;
 
-        this.provider = provider || new HttpProvider();
+        this.provider = new HttpProvider("https://toncenter.com/api/v2/jsonRPC", provider);
         this.wallet = new Wallets(this.provider);
         this.lockupWallet = LockupWallets;
     }

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -12,7 +12,7 @@ class HttpProvider {
      * @param options? {{apiKey: string}}
      */
     constructor(host, options) {
-        this.host = host || "https://toncenter.com/api/v2/jsonRPC";
+        this.host = host;
         this.options = options || {};
     }
 


### PR DESCRIPTION
In the original version, to specify apiKey, you need to send the full HttpProvider to the TonWeb constructor. In my version, you only need to enter an object with apiKey