### PR TITLE
Fixed indexes serialization in BOC

### DIFF
--- a/src/boc/Cell.js
+++ b/src/boc/Cell.js
@@ -209,8 +209,8 @@ class Cell {
         let sizeIndex = [];
         for (let cell_info of topologicalOrder) {
             //TODO it should be async map or async for
-            sizeIndex.push(full_size);
             full_size = full_size + await cell_info[1].bocSerializationSize(cellsIndex, s_bytes);
+            sizeIndex.push(full_size);
         }
         const offset_bits = full_size.toString(2).length; // Minimal number of bits to offset/len (unused?)
         const offset_bytes = Math.max(Math.ceil(offset_bits / 8), 1);


### PR DESCRIPTION
Current behavior seems incorrect, index should store end of cell, not start.

This is how its implemented in ton node:
https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/vm/boc.cpp#L545

Havent found exact place where index is used on deserialization, is its implemented without index usage currently?