### PR TITLE
chore: update document for transfer amount to use string

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ await wallet.deploy(secretKey).send(); // deploy wallet to blockchain
 const fee = await wallet.methods.transfer({
     secretKey,
     toAddress: 'EQDjVXa_oltdBP64Nc__p397xLCvGm2IcZ1ba7anSW0NAkeP',
-    amount: TonWeb.utils.toNano(0.01), // 0.01 TON
+    amount: TonWeb.utils.toNano('0.01'), // 0.01 TON
     seqno: seqno,
     payload: 'Hello',
     sendMode: 3,


### PR DESCRIPTION
I'm trying to use this library and found sample code has an error.
`Error: Please pass numbers as strings or BN objects to avoid precision errors.`