### PR TITLE
Fix to make tonweb compatible with Python module "ton-http-api"

### DIFF
--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -49,7 +49,7 @@ class HttpProvider {
     send(method, params) {
         return this.sendImpl(
             this.host,
-            {id: 1, jsonrpc: "2.0", method: method, params: params}
+            {id: "1", jsonrpc: "2.0", method: method, params: params}
         );
     }
 


### PR DESCRIPTION
According to the TonRequestJsonRPC scheme, the "id" field must have 'string' type.

If the "id" field is a number, the Python ton-http-api module returns the following error: 
`"error": "Validation error: [{'type': 'string_type', 'loc': ('body', 'id'), 'msg': 'Input should be a valid string'`

The TonCenter endpoint (https://toncenter.com/api/v2/jsonRPC) works well because the "id" value is converted to a string somewhere on its way to the server. It also has string type in the response.

TonRequestJsonRPC scheme from https://toncenter.com/api/v2/openapi.json
```json
"TonRequestJsonRPC": {
    "title": "TonRequestJsonRPC",
    "required": [
        "method"
    ],
    "type": "object",
    "properties": {
        "method": {
            "title": "Method",
            "type": "string"
        },
        "params": {
            "title": "Params",
            "type": "object",
            "default": {}
        },
        "id": {
            "title": "Id",
            "type": "string"
        },
        "jsonrpc": {
            "title": "Jsonrpc",
            "type": "string"
        }
    }
}
```