### PR TITLE
Fix(jetton): wrong params tokenAmount -> jettonAmount

### DIFF
--- a/dist/types/contract/token/ft/jetton-minter.d.ts
+++ b/dist/types/contract/token/ft/jetton-minter.d.ts
@@ -12,7 +12,7 @@ export interface JettonMinterOptions extends ContractOptions {
 export interface JettonMinterMethods extends ContractMethods {
 }
 export interface MintBodyParams {
-    tokenAmount: BN;
+    jettonAmount: BN;
     destination: Address;
     amount: BN;
     queryId?: number;

--- a/dist/types/contract/token/ft/jetton-wallet.d.ts
+++ b/dist/types/contract/token/ft/jetton-wallet.d.ts
@@ -16,7 +16,7 @@ export interface WalletData {
 }
 export interface TransferBodyParams {
     queryId?: number;
-    tokenAmount: BN;
+    jettonAmount: BN;
     toAddress: Address;
     responseAddress: Address;
     forwardAmount?: BN;
@@ -24,7 +24,7 @@ export interface TransferBodyParams {
 }
 export interface BurnBodyParams {
     queryId?: number;
-    tokenAmount: BN;
+    jettonAmount: BN;
     responseAddress: Address;
 }
 /**


### PR DESCRIPTION
When I write a jetton transfer using typescript, the transfer amount is 0. According to the documentation and code, it should be using jettonAmount.